### PR TITLE
feat: add RFID platform channel

### DIFF
--- a/android/src/main/kotlin/com/example/urovo_rfid/UrovoRfidPlugin.kt
+++ b/android/src/main/kotlin/com/example/urovo_rfid/UrovoRfidPlugin.kt
@@ -1,33 +1,147 @@
 package com.example.urovo_rfid
 
+import android.os.Handler
+import android.os.Looper
 import io.flutter.embedding.engine.plugins.FlutterPlugin
+import io.flutter.plugin.common.EventChannel
 import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler
 import io.flutter.plugin.common.MethodChannel.Result
 
-/** UrovoRfidPlugin */
-class UrovoRfidPlugin: FlutterPlugin, MethodCallHandler {
-  /// The MethodChannel that will the communication between Flutter and native Android
-  ///
-  /// This local reference serves to register the plugin with the Flutter Engine and unregister it
-  /// when the Flutter Engine is detached from the Activity
-  private lateinit var channel : MethodChannel
+// The following imports correspond to the Urovo RFID SDK.  They are not
+// included with this repository but illustrate the expected integration.
+// import com.urovo.sdk.rfid.IRfidCallback
+// import com.urovo.sdk.rfid.InitListener
+// import com.urovo.sdk.rfid.RFIDSDKManager
+// import com.urovo.sdk.rfid.RfidManager
+// import com.urovo.sdk.rfid.RfidParameter
 
-  override fun onAttachedToEngine(flutterPluginBinding: FlutterPlugin.FlutterPluginBinding) {
-    channel = MethodChannel(flutterPluginBinding.binaryMessenger, "urovo_rfid")
+/** UrovoRfidPlugin */
+class UrovoRfidPlugin : FlutterPlugin, MethodCallHandler, EventChannel.StreamHandler {
+  /// Method channel bridging Flutter calls to the native SDK.
+  private lateinit var channel: MethodChannel
+
+  /// Event channel used to emit inventory callbacks back to Flutter.
+  private lateinit var eventChannel: EventChannel
+
+  private var eventSink: EventChannel.EventSink? = null
+
+  // Reference to the native RFID manager instance.
+  private var rfidManager: Any? = null // RfidManager
+
+  private val mainHandler = Handler(Looper.getMainLooper())
+
+  override fun onAttachedToEngine(binding: FlutterPlugin.FlutterPluginBinding) {
+    channel = MethodChannel(binding.binaryMessenger, "urovo_rfid")
     channel.setMethodCallHandler(this)
+
+    eventChannel = EventChannel(binding.binaryMessenger, "urovo_rfid/events")
+    eventChannel.setStreamHandler(this)
   }
 
   override fun onMethodCall(call: MethodCall, result: Result) {
-    if (call.method == "getPlatformVersion") {
-      result.success("Android ${android.os.Build.VERSION.RELEASE}")
-    } else {
-      result.notImplemented()
+    when (call.method) {
+      "getPlatformVersion" -> result.success("Android ${android.os.Build.VERSION.RELEASE}")
+      "init" -> initRfid(result)
+      "startInventory" -> {
+        val session = call.argument<Int>("session") ?: 0
+        // (rfidManager as? RfidManager)?.startInventory(session)
+        result.success(null)
+      }
+      "stopInventory" -> {
+        // (rfidManager as? RfidManager)?.stopInventory()
+        result.success(null)
+      }
+      "readTag" -> {
+        // Parameters for readTag
+        val epc = call.argument<String>("epc")
+        val memBank = call.argument<Int>("memBank") ?: 0
+        val wordAdd = call.argument<Int>("wordAdd") ?: 0
+        val wordCnt = call.argument<Int>("wordCnt") ?: 0
+        val password = call.argument<List<Int>>("password")?.toIntArray()
+
+        // val data = (rfidManager as? RfidManager)?.readTag(epc, memBank.toByte(), wordAdd.toByte(), wordCnt.toByte(), password)
+        // Placeholder response map
+        val map = hashMapOf<String, Any?>("data" to null)
+        result.success(map)
+      }
+      "writeTag" -> {
+        val epc = call.argument<String>("epc")
+        val password = call.argument<List<Int>>("password")?.toIntArray()
+        val memBank = call.argument<Int>("memBank") ?: 0
+        val wordAdd = call.argument<Int>("wordAdd") ?: 0
+        val data = call.argument<List<Int>>("data")?.toIntArray()
+        // val ret = (rfidManager as? RfidManager)?.writeTag(epc, password, memBank.toByte(), wordAdd.toByte(), data)
+        val ret: Int? = 0
+        result.success(ret)
+      }
+      "writeTagEpc" -> {
+        val epc = call.argument<String>("epc")
+        val password = call.argument<String>("password")
+        val data = call.argument<String>("data")
+        // val ret = (rfidManager as? RfidManager)?.writeTagEpc(epc, password, data)
+        val ret: Int? = 0
+        result.success(ret)
+      }
+      "getOutputPower" -> {
+        // val power = (rfidManager as? RfidManager)?.getOutputPower()
+        val power: Int? = 0
+        result.success(power)
+      }
+      "setOutputPower" -> {
+        val power = call.argument<Int>("power") ?: 0
+        // val ret = (rfidManager as? RfidManager)?.setOutputPower(power)
+        val ret: Int? = 0
+        result.success(ret)
+      }
+      "setInventoryParameter" -> {
+        // val params = RfidParameter()
+        // Map incoming arguments to params fields
+        result.success(null)
+      }
+      "enableScanHead" -> {
+        val enable = call.argument<Boolean>("enable") ?: false
+        // RFIDSDKManager.getInstance().enableScanHead(enable)
+        result.success(null)
+      }
+      else -> result.notImplemented()
     }
+  }
+
+  private fun initRfid(result: Result) {
+    // RFIDSDKManager.getInstance().init(object : InitListener {
+    //   override fun onStatus(status: Boolean) {
+    //     if (status) {
+    //       rfidManager = RFIDSDKManager.getInstance().getRfidManager()
+    //       (rfidManager as? RfidManager)?.setRfidCallback(object : IRfidCallback {
+    //         override fun onInventoryTag(epc: String, tid: String, rssi: String) {
+    //           mainHandler.post { eventSink?.success(mapOf("epc" to epc, "tid" to tid, "rssi" to rssi)) }
+    //         }
+
+    //         override fun onInventoryTagEnd() {
+    //           mainHandler.post { eventSink?.endOfStream() }
+    //         }
+    //       })
+    //       result.success(true)
+    //     } else {
+    //       result.success(false)
+    //     }
+    //   }
+    // })
+    result.success(true)
+  }
+
+  override fun onListen(arguments: Any?, events: EventChannel.EventSink) {
+    eventSink = events
+  }
+
+  override fun onCancel(arguments: Any?) {
+    eventSink = null
   }
 
   override fun onDetachedFromEngine(binding: FlutterPlugin.FlutterPluginBinding) {
     channel.setMethodCallHandler(null)
+    eventChannel.setStreamHandler(null)
   }
 }

--- a/lib/urovo_rfid.dart
+++ b/lib/urovo_rfid.dart
@@ -1,8 +1,58 @@
 
 import 'urovo_rfid_platform_interface.dart';
 
+/// Public API exposed to Flutter applications.
 class UrovoRfid {
-  Future<String?> getPlatformVersion() {
-    return UrovoRfidPlatform.instance.getPlatformVersion();
-  }
+  UrovoRfidPlatform get _platform => UrovoRfidPlatform.instance;
+
+  /// Current stream of inventory events emitted by the native plugin.
+  Stream<Map<String, dynamic>> get inventoryStream => _platform.inventoryStream;
+
+  /// Initialize the underlying RFID manager.
+  Future<bool?> init() => _platform.init();
+
+  /// Begin scanning for tags.
+  Future<void> startInventory(int session) => _platform.startInventory(session);
+
+  /// Stop the current inventory operation.
+  Future<void> stopInventory() => _platform.stopInventory();
+
+  /// Read tag data from the device.
+  Future<Map<String, dynamic>?> readTag(
+    String epc,
+    int memBank,
+    int wordAdd,
+    int wordCnt,
+    List<int> password,
+  ) =>
+      _platform.readTag(epc, memBank, wordAdd, wordCnt, password);
+
+  /// Write tag memory contents.
+  Future<int?> writeTag(
+    String epc,
+    List<int> password,
+    int memBank,
+    int wordAdd,
+    List<int> data,
+  ) =>
+      _platform.writeTag(epc, password, memBank, wordAdd, data);
+
+  /// Write the EPC region of a tag.
+  Future<int?> writeTagEpc(String epc, String password, String data) =>
+      _platform.writeTagEpc(epc, password, data);
+
+  /// Query reader output power in dBm.
+  Future<int?> getOutputPower() => _platform.getOutputPower();
+
+  /// Set reader output power in dBm.
+  Future<int?> setOutputPower(int power) => _platform.setOutputPower(power);
+
+  /// Update inventory parameters.
+  Future<void> setInventoryParameter(Map<String, dynamic> params) =>
+      _platform.setInventoryParameter(params);
+
+  /// Enable or disable the scanning head light.
+  Future<void> enableScanHead(bool enable) => _platform.enableScanHead(enable);
+
+  Future<String?> getPlatformVersion() => _platform.getPlatformVersion();
 }

--- a/lib/urovo_rfid_method_channel.dart
+++ b/lib/urovo_rfid_method_channel.dart
@@ -9,9 +9,105 @@ class MethodChannelUrovoRfid extends UrovoRfidPlatform {
   @visibleForTesting
   final methodChannel = const MethodChannel('urovo_rfid');
 
+  /// Event channel used for streaming inventory callbacks from the reader.
+  @visibleForTesting
+  final EventChannel eventChannel = const EventChannel('urovo_rfid/events');
+
+  @override
+  Stream<Map<String, dynamic>> get inventoryStream =>
+      eventChannel.receiveBroadcastStream().map((event) =>
+          Map<String, dynamic>.from(event as Map));
+
+  @override
+  Future<bool?> init() async {
+    return await methodChannel.invokeMethod<bool>('init');
+  }
+
+  @override
+  Future<void> startInventory(int session) async {
+    await methodChannel.invokeMethod('startInventory', {'session': session});
+  }
+
+  @override
+  Future<void> stopInventory() async {
+    await methodChannel.invokeMethod('stopInventory');
+  }
+
+  @override
+  Future<Map<String, dynamic>?> readTag(
+    String epc,
+    int memBank,
+    int wordAdd,
+    int wordCnt,
+    List<int> password,
+  ) async {
+    final result = await methodChannel.invokeMapMethod<String, dynamic>(
+      'readTag',
+      {
+        'epc': epc,
+        'memBank': memBank,
+        'wordAdd': wordAdd,
+        'wordCnt': wordCnt,
+        'password': password,
+      },
+    );
+    return result;
+  }
+
+  @override
+  Future<int?> writeTag(
+    String epc,
+    List<int> password,
+    int memBank,
+    int wordAdd,
+    List<int> data,
+  ) async {
+    return await methodChannel.invokeMethod<int>('writeTag', {
+      'epc': epc,
+      'password': password,
+      'memBank': memBank,
+      'wordAdd': wordAdd,
+      'data': data,
+    });
+  }
+
+  @override
+  Future<int?> writeTagEpc(String epc, String password, String data) async {
+    return await methodChannel.invokeMethod<int>('writeTagEpc', {
+      'epc': epc,
+      'password': password,
+      'data': data,
+    });
+  }
+
+  @override
+  Future<int?> getOutputPower() async {
+    return await methodChannel.invokeMethod<int>('getOutputPower');
+  }
+
+  @override
+  Future<int?> setOutputPower(int power) async {
+    return await methodChannel.invokeMethod<int>('setOutputPower', {
+      'power': power,
+    });
+  }
+
+  @override
+  Future<void> setInventoryParameter(Map<String, dynamic> params) async {
+    await methodChannel.invokeMethod('setInventoryParameter', params);
+  }
+
+  @override
+  Future<void> enableScanHead(bool enable) async {
+    await methodChannel.invokeMethod('enableScanHead', {
+      'enable': enable,
+    });
+  }
+
   @override
   Future<String?> getPlatformVersion() async {
-    final version = await methodChannel.invokeMethod<String>('getPlatformVersion');
+    final version =
+        await methodChannel.invokeMethod<String>('getPlatformVersion');
     return version;
   }
 }

--- a/lib/urovo_rfid_platform_interface.dart
+++ b/lib/urovo_rfid_platform_interface.dart
@@ -23,6 +23,60 @@ abstract class UrovoRfidPlatform extends PlatformInterface {
     _instance = instance;
   }
 
+  /// Stream of tag inventory events.  Each event is a map containing
+  /// `epc`, `tid` and `rssi` values returned from the reader.
+  Stream<Map<String, dynamic>> get inventoryStream {
+    throw UnimplementedError('inventoryStream has not been implemented.');
+  }
+
+  /// Initialize the RFID manager.  Returns `true` when the underlying SDK
+  /// reports a successful connection.
+  Future<bool?> init();
+
+  /// Begin inventory scanning using the provided [session].
+  Future<void> startInventory(int session);
+
+  /// Stop any ongoing inventory scans.
+  Future<void> stopInventory();
+
+  /// Read tag data from the specified memory [memBank].  The password is
+  /// supplied as a 4-byte array in [password].
+  Future<Map<String, dynamic>?> readTag(
+    String epc,
+    int memBank,
+    int wordAdd,
+    int wordCnt,
+    List<int> password,
+  );
+
+  /// Write tag data to the specified memory [memBank].  Returns the error
+  /// code reported by the SDK.
+  Future<int?> writeTag(
+    String epc,
+    List<int> password,
+    int memBank,
+    int wordAdd,
+    List<int> data,
+  );
+
+  /// Convenience method for writing the EPC region.
+  Future<int?> writeTagEpc(String epc, String password, String data);
+
+  /// Query the current reader output power in dBm.
+  Future<int?> getOutputPower();
+
+  /// Set the reader output power in dBm.  Returns the error code from the
+  /// SDK where `0` generally represents success.
+  Future<int?> setOutputPower(int power);
+
+  /// Adjust inventory parameters such as `session`, `interval`, and
+  /// `qValue`.  The expected keys mirror those described in the SDK
+  /// documentation.
+  Future<void> setInventoryParameter(Map<String, dynamic> params);
+
+  /// Enable or disable the long range handle scanning head light.
+  Future<void> enableScanHead(bool enable);
+
   Future<String?> getPlatformVersion() {
     throw UnimplementedError('platformVersion() has not been implemented.');
   }

--- a/test/urovo_rfid_test.dart
+++ b/test/urovo_rfid_test.dart
@@ -10,6 +10,43 @@ class MockUrovoRfidPlatform
 
   @override
   Future<String?> getPlatformVersion() => Future.value('42');
+
+  @override
+  Stream<Map<String, dynamic>> get inventoryStream => const Stream.empty();
+
+  @override
+  Future<bool?> init() async => true;
+
+  @override
+  Future<void> startInventory(int session) async {}
+
+  @override
+  Future<void> stopInventory() async {}
+
+  @override
+  Future<Map<String, dynamic>?> readTag(
+          String epc, int memBank, int wordAdd, int wordCnt, List<int> password) async =>
+      {};
+
+  @override
+  Future<int?> writeTag(String epc, List<int> password, int memBank,
+          int wordAdd, List<int> data) async =>
+      0;
+
+  @override
+  Future<int?> writeTagEpc(String epc, String password, String data) async => 0;
+
+  @override
+  Future<int?> getOutputPower() async => 0;
+
+  @override
+  Future<int?> setOutputPower(int power) async => 0;
+
+  @override
+  Future<void> setInventoryParameter(Map<String, dynamic> params) async {}
+
+  @override
+  Future<void> enableScanHead(bool enable) async {}
 }
 
 void main() {


### PR DESCRIPTION
## Summary
- expose initialization, inventory, tag read/write, power and parameter controls in the Flutter API
- add method and event channels that bridge to the Urovo RFID SDK on Android
- stub Android implementation for RFID callbacks and operations

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689b38fb7844832f84abc412df5caaaf