### PR TITLE
Add missing Android dependencies for Urovo RFID plugin

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -18,6 +18,9 @@ allprojects {
     repositories {
         google()
         mavenCentral()
+        flatDir {
+            dirs 'libs'
+        }
     }
 }
 
@@ -51,9 +54,8 @@ android {
         testImplementation("org.jetbrains.kotlin:kotlin-test")
         testImplementation("org.mockito:mockito-core:5.0.0")
         implementation files('libs/platform_sdk_v3.1.221124.jar')
-
-
-        implementation files('libs/URFIDLibrary-v2.4.0125.aar')
+        implementation(name: 'URFIDLibrary-v2.4.0125', ext: 'aar')
+        implementation 'com.google.code.gson:gson:2.10.1'
     }
 
     testOptions {


### PR DESCRIPTION
## Summary
- expose libs directory to Gradle so AAR dependencies resolve
- depend on the URFID SDK AAR and add Gson for JSON parsing

## Testing
- `gradle -p android build` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689b4d1dcc28832fac0079805cfd7380